### PR TITLE
Remove leftover floating mode toggle in settings (Task 1)

### DIFF
--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -29,7 +29,6 @@
     <CheckBoxPreference android:key="floating_debug_mode" android:title="Floating Keyboard Debug" android:summary="Show debug toasts for floating keyboard interactions" android:defaultValue="false"/>
   </PreferenceCategory>
   <PreferenceCategory android:title="@string/pref_category_style">
-    <CheckBoxPreference android:key="floating_keyboard" android:title="Floating Keyboard" android:summary="Detach keyboard from bottom and allow positioning" android:defaultValue="false"/>
     <ListPreference android:key="theme" android:title="@string/pref_theme" android:summary="%s" android:defaultValue="system" android:entries="@array/pref_theme_entries" android:entryValues="@array/pref_theme_values"/>
     <juloo.keyboard2.fork.prefs.IntSlideBarPreference android:key="label_brightness" android:title="@string/pref_label_brightness" android:summary="%s%%" android:defaultValue="100" min="50" max="100"/>
     <juloo.keyboard2.fork.prefs.IntSlideBarPreference android:key="keyboard_opacity" android:title="@string/pref_keyboard_opacity" android:summary="%s%%" android:defaultValue="100" min="0" max="100"/>


### PR DESCRIPTION
## Summary
Remove the legacy floating keyboard toggle from settings.xml as it's now handled via the system IME switcher.

## Changes
- Removed unused CheckBoxPreference with key "floating_keyboard" from res/xml/settings.xml line 32
- Cleaned up legacy setting that was no longer functional since floating mode is now handled by dual IME system

## Test plan
- [ ] Verify settings UI no longer shows the legacy floating keyboard option
- [ ] Confirm floating mode still works via system IME switcher
- [ ] Check that no functionality was lost with this cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)