### PR TITLE
Add switch_to_layout_<layoutName> key action and toggle_persistence (Tasks 10-11)

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -108,6 +108,7 @@
     <string name="key_descr_change_method">Switch keyboard</string>
     <string name="key_descr_voice_typing">Voice typing</string>
     <string name="key_descr_toggle_floating">Toggle floating keyboard</string>
+    <string name="key_descr_toggle_persistence">Toggle keyboard persistence</string>
     <string name="key_descr_copy">Copy</string>
     <string name="key_descr_paste">Paste</string>
     <string name="key_descr_cut">Cut</string>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -27,6 +27,7 @@
     <juloo.keyboard2.fork.prefs.IntSlideBarPreference android:dependency="vibrate_custom" android:key="vibrate_duration" android:title="@string/pref_vibrate_duration_title" android:summary="%sms" android:defaultValue="20" min="0" max="100"/>
     <ListPreference android:key="number_entry_layout" android:title="@string/pref_number_entry_title" android:summary="%s" android:defaultValue="pin" android:entries="@array/pref_number_entry_entries" android:entryValues="@array/pref_number_entry_values"/>
     <CheckBoxPreference android:key="floating_debug_mode" android:title="Floating Keyboard Debug" android:summary="Show debug toasts for floating keyboard interactions" android:defaultValue="false"/>
+    <CheckBoxPreference android:key="keyboard_persistence_enabled" android:title="Keyboard Persistence" android:summary="Keep floating keyboard visible even when no text field is focused" android:defaultValue="false"/>
   </PreferenceCategory>
   <PreferenceCategory android:title="@string/pref_category_style">
     <CheckBoxPreference android:key="floating_keyboard" android:title="Floating Keyboard" android:summary="Detach keyboard from bottom and allow positioning" android:defaultValue="false"/>

--- a/srcs/juloo.keyboard2.fork/Config.java
+++ b/srcs/juloo.keyboard2.fork/Config.java
@@ -73,6 +73,7 @@ public final class Config
   public boolean borderConfig;
   public int circle_sensitivity;
   public boolean clipboard_history_enabled;
+  public boolean keyboard_persistence_enabled;
 
   // Dynamically set
   public boolean shouldOfferVoiceTyping;
@@ -189,6 +190,7 @@ public final class Config
     current_layout_wide = _prefs.getInt("current_layout_landscape", 0);
     circle_sensitivity = Integer.valueOf(_prefs.getString("circle_sensitivity", "2"));
     clipboard_history_enabled = _prefs.getBoolean("clipboard_history_enabled", false);
+    keyboard_persistence_enabled = _prefs.getBoolean("keyboard_persistence_enabled", false);
 
     float screen_width_dp = dm.widthPixels / dm.density;
     wide_screen = screen_width_dp >= WIDE_DEVICE_THRESHOLD;
@@ -217,6 +219,12 @@ public final class Config
   {
     clipboard_history_enabled = e;
     _prefs.edit().putBoolean("clipboard_history_enabled", e).commit();
+  }
+
+  public void set_keyboard_persistence_enabled(boolean e)
+  {
+    keyboard_persistence_enabled = e;
+    _prefs.edit().putBoolean("keyboard_persistence_enabled", e).commit();
   }
 
   private float get_dip_pref(DisplayMetrics dm, String pref_name, float def)

--- a/srcs/juloo.keyboard2.fork/FloatingKeyboard2.java
+++ b/srcs/juloo.keyboard2.fork/FloatingKeyboard2.java
@@ -239,16 +239,26 @@ public class FloatingKeyboard2 extends InputMethodService
   public void onFinishInputView(boolean finishingInput)
   {
     super.onFinishInputView(finishingInput);
-    // Hide floating keyboard when input view is finished
-    removeFloatingKeyboard();
+    // Only hide floating keyboard if persistence is disabled
+    if (!_config.keyboard_persistence_enabled) {
+      android.util.Log.d("juloo.keyboard2.fork", "Hiding floating keyboard (persistence disabled)");
+      removeFloatingKeyboard();
+    } else {
+      android.util.Log.d("juloo.keyboard2.fork", "Keeping floating keyboard visible (persistence enabled)");
+    }
   }
 
   @Override
   public void onFinishInput()
   {
     super.onFinishInput();
-    // Also hide when input is completely finished
-    removeFloatingKeyboard();
+    // Only hide when input is completely finished if persistence is disabled
+    if (!_config.keyboard_persistence_enabled) {
+      android.util.Log.d("juloo.keyboard2.fork", "Hiding floating keyboard on finish input (persistence disabled)");
+      removeFloatingKeyboard();
+    } else {
+      android.util.Log.d("juloo.keyboard2.fork", "Keeping floating keyboard visible on finish input (persistence enabled)");
+    }
   }
 
   private void refresh_action_label(EditorInfo info)
@@ -359,6 +369,10 @@ public class FloatingKeyboard2 extends InputMethodService
         case TOGGLE_FLOATING:
           switch_to_docked_ime();
           break;
+
+        case TOGGLE_PERSISTENCE:
+          toggle_keyboard_persistence();
+          break;
       }
     }
 
@@ -417,6 +431,20 @@ public class FloatingKeyboard2 extends InputMethodService
       // Fallback - show IME picker so user can manually select
       imm.showInputMethodPicker();
     }
+  }
+
+  private void toggle_keyboard_persistence()
+  {
+    boolean currentState = _config.keyboard_persistence_enabled;
+    boolean newState = !currentState;
+    
+    android.util.Log.d("juloo.keyboard2.fork", "Toggling keyboard persistence from " + currentState + " to " + newState);
+    
+    _config.set_keyboard_persistence_enabled(newState);
+    
+    // Show toast feedback to user
+    String message = newState ? "Keyboard persistence enabled" : "Keyboard persistence disabled";
+    Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
   }
 
   private View inflate_view(int layout)

--- a/srcs/juloo.keyboard2.fork/KeyEventHandler.java
+++ b/srcs/juloo.keyboard2.fork/KeyEventHandler.java
@@ -99,7 +99,13 @@ public final class KeyEventHandler
     {
       case Char: send_text(String.valueOf(key.getChar())); break;
       case String: send_text(key.getString()); break;
-      case Event: _recv.handle_event_key(key.getEvent()); break;
+      case Event: 
+        if (key.getEvent() == KeyValue.Event.SWITCH_TO_LAYOUT) {
+          _recv.handle_event_key_with_value(key);
+        } else {
+          _recv.handle_event_key(key.getEvent());
+        }
+        break;
       case Keyevent: send_key_down_up(key.getKeyevent()); break;
       case Modifier: break;
       case Editing: handle_editing_key(key.getEditing()); break;
@@ -634,6 +640,7 @@ public final class KeyEventHandler
   public static interface IReceiver
   {
     public void handle_event_key(KeyValue.Event ev);
+    public void handle_event_key_with_value(KeyValue keyValue);
     public void set_shift_state(boolean state, boolean lock);
     public void set_compose_pending(boolean pending);
     public void selection_state_changed(boolean selection_is_ongoing);

--- a/srcs/juloo.keyboard2.fork/KeyValue.java
+++ b/srcs/juloo.keyboard2.fork/KeyValue.java
@@ -24,6 +24,7 @@ public final class KeyValue implements Comparable<KeyValue>
     SWITCH_VOICE_TYPING,
     SWITCH_VOICE_TYPING_CHOOSER,
     TOGGLE_FLOATING,
+    TOGGLE_PERSISTENCE,
     SWITCH_TO_LAYOUT,
   }
 
@@ -642,6 +643,7 @@ public final class KeyValue implements Comparable<KeyValue>
       case "voice_typing": return eventKey(0xE015, Event.SWITCH_VOICE_TYPING, FLAG_SMALLER_FONT);
       case "voice_typing_chooser": return eventKey(0xE015, Event.SWITCH_VOICE_TYPING_CHOOSER, FLAG_SMALLER_FONT);
       case "toggle_floating": return eventKey("Float", Event.TOGGLE_FLOATING, FLAG_SMALLER_FONT);
+      case "toggle_persistence": return eventKey("Persist", Event.TOGGLE_PERSISTENCE, FLAG_SMALLER_FONT);
 
       /* Key events */
       case "esc": return keyeventKey("Esc", KeyEvent.KEYCODE_ESCAPE, FLAG_SMALLER_FONT);

--- a/srcs/juloo.keyboard2.fork/KeyValue.java
+++ b/srcs/juloo.keyboard2.fork/KeyValue.java
@@ -24,6 +24,7 @@ public final class KeyValue implements Comparable<KeyValue>
     SWITCH_VOICE_TYPING,
     SWITCH_VOICE_TYPING_CHOOSER,
     TOGGLE_FLOATING,
+    SWITCH_TO_LAYOUT,
   }
 
   // Must be evaluated in the reverse order of their values.
@@ -184,6 +185,12 @@ public final class KeyValue implements Comparable<KeyValue>
   public Event getEvent()
   {
     return Event.values()[(_code & VALUE_BITS)];
+  }
+
+  /** Defined only when [getKind() == Kind.Event] and [getEvent() == Event.SWITCH_TO_LAYOUT]. */
+  public String getLayoutName()
+  {
+    return _payload.toString();
   }
 
   /** Defined only when [getKind() == Kind.Modifier]. */
@@ -516,6 +523,17 @@ public final class KeyValue implements Comparable<KeyValue>
 
   public static KeyValue getSpecialKeyByName(String name)
   {
+    // Handle dynamic switch_to_layout_<layoutName> actions
+    if (name.startsWith("switch_to_layout_")) {
+      String layoutName = name.substring("switch_to_layout_".length());
+      // Clean layout name - replace underscores with spaces and ensure valid characters
+      String cleanLayoutName = layoutName.replaceAll("_", " ");
+      // Create a compact display name by taking first few characters
+      String displayName = cleanLayoutName.length() > 6 ? cleanLayoutName.substring(0, 6) + "…" : cleanLayoutName;
+      return new KeyValue(layoutName, Kind.Event, Event.SWITCH_TO_LAYOUT.ordinal(), 
+                         FLAG_SPECIAL | FLAG_SECONDARY | FLAG_SMALLER_FONT);
+    }
+    
     switch (name)
     {
       /* These symbols have special meaning when in `srcs/layouts` and are

--- a/srcs/juloo.keyboard2.fork/Keyboard2.java
+++ b/srcs/juloo.keyboard2.fork/Keyboard2.java
@@ -495,6 +495,17 @@ public class Keyboard2 extends InputMethodService
         case TOGGLE_FLOATING:
           switch_to_floating_ime();
           break;
+
+        case SWITCH_TO_LAYOUT:
+          // This should never be called since SWITCH_TO_LAYOUT uses handle_event_key_with_value
+          break;
+      }
+    }
+
+    public void handle_event_key_with_value(KeyValue keyValue)
+    {
+      if (keyValue.getEvent() == KeyValue.Event.SWITCH_TO_LAYOUT) {
+        switch_to_layout_by_name(keyValue.getLayoutName());
       }
     }
 
@@ -546,6 +557,76 @@ public class Keyboard2 extends InputMethodService
       // Fallback - show IME picker so user can manually select
       imm.showInputMethodPicker();
     }
+  }
+
+  private void switch_to_layout_by_name(String layoutName)
+  {
+    if (layoutName == null || layoutName.isEmpty()) {
+      android.util.Log.w("juloo.keyboard2.fork", "Cannot switch to layout: name is null or empty");
+      return;
+    }
+
+    android.util.Log.d("juloo.keyboard2.fork", "Switching to layout by name: " + layoutName);
+
+    // Find matching layout in available layouts
+    for (int i = 0; i < _config.layouts.size(); i++) {
+      KeyboardData layout = _config.layouts.get(i);
+      if (layout != null && layout.name != null) {
+        // Compare layout names (case-insensitive, handle spaces/underscores)
+        String normalizedLayoutName = layout.name.toLowerCase().replaceAll("\\s+", "_");
+        String normalizedTargetName = layoutName.toLowerCase().replaceAll("\\s+", "_");
+        
+        if (normalizedLayoutName.equals(normalizedTargetName) || 
+            normalizedLayoutName.contains(normalizedTargetName) ||
+            normalizedTargetName.contains(normalizedLayoutName)) {
+          android.util.Log.d("juloo.keyboard2.fork", "Found matching layout at index " + i + ": " + layout.name);
+          setTextLayout(i);
+          return;
+        }
+      }
+    }
+
+    // If no exact match found, try matching against layout resource names
+    String[] layoutValues = getResources().getStringArray(R.array.pref_layout_values);
+    String[] layoutEntries = getResources().getStringArray(R.array.pref_layout_entries);
+    
+    for (int i = 0; i < layoutValues.length && i < layoutEntries.length; i++) {
+      String layoutValue = layoutValues[i];
+      String layoutEntry = layoutEntries[i];
+      
+      // Normalize and compare layout value names
+      String normalizedValue = layoutValue.toLowerCase().replaceAll("_", " ");
+      String normalizedEntry = layoutEntry.toLowerCase();
+      String normalizedTarget = layoutName.toLowerCase().replaceAll("_", " ");
+      
+      if (normalizedValue.contains(normalizedTarget) || 
+          normalizedEntry.contains(normalizedTarget) ||
+          normalizedTarget.contains(normalizedValue)) {
+        
+        // Find this layout in the config layouts
+        try {
+          int resourceId = getResources().getIdentifier(layoutValue, "xml", getPackageName());
+          if (resourceId != 0) {
+            KeyboardData targetLayout = KeyboardData.load(getResources(), resourceId);
+            if (targetLayout != null) {
+              // Find or add this layout to the config
+              for (int j = 0; j < _config.layouts.size(); j++) {
+                if (_config.layouts.get(j) == targetLayout) {
+                  android.util.Log.d("juloo.keyboard2.fork", "Found matching layout resource at index " + j + ": " + layoutEntry);
+                  setTextLayout(j);
+                  return;
+                }
+              }
+            }
+          }
+        } catch (Exception e) {
+          android.util.Log.w("juloo.keyboard2.fork", "Error loading layout resource: " + layoutValue, e);
+        }
+      }
+    }
+
+    android.util.Log.w("juloo.keyboard2.fork", "Could not find layout matching name: " + layoutName);
+    Toast.makeText(this, "Layout not found: " + layoutName, Toast.LENGTH_SHORT).show();
   }
 
   private View inflate_view(int layout)

--- a/srcs/juloo.keyboard2.fork/prefs/ExtraKeysPreference.java
+++ b/srcs/juloo.keyboard2.fork/prefs/ExtraKeysPreference.java
@@ -125,6 +125,7 @@ public class ExtraKeysPreference extends PreferenceCategory
     "combining_kavyka",
     "combining_palatalization",
     "toggle_floating",
+    "toggle_persistence",
   };
 
   /** Whether an extra key is enabled by default. */
@@ -198,6 +199,7 @@ public class ExtraKeysPreference extends PreferenceCategory
       case "undo": id = R.string.key_descr_undo; break;
       case "voice_typing": id = R.string.key_descr_voice_typing; break;
       case "toggle_floating": id = R.string.key_descr_toggle_floating; break;
+      case "toggle_persistence": id = R.string.key_descr_toggle_persistence; break;
       case "ª": id = R.string.key_descr_ª; break;
       case "º": id = R.string.key_descr_º; break;
       case "switch_clipboard": id = R.string.key_descr_clipboard; break;


### PR DESCRIPTION
## Summary
Implemented parameterized layout switching and keyboard persistence functionality.

## Changes

### Task 10: switch_to_layout_<layoutName> key action
- Added SWITCH_TO_LAYOUT event to KeyValue.Event enum
- Implemented pattern matching for "switch_to_layout_<layoutName>" syntax
- Added getLayoutName() method for parameter extraction
- Modified KeyEventHandler for parameterized events
- Implemented fuzzy layout name matching with user feedback

### Task 11: toggle_persistence key action
- Added TOGGLE_PERSISTENCE event and keyboard_persistence_enabled config
- Implemented toggle_keyboard_persistence() method
- Modified onFinishInputView() and onFinishInput() to respect persistence setting
- Added persistence setting to settings.xml with checkbox preference
- Added proper synchronization between key toggle and settings

## Test plan
- [ ] Test switch_to_layout_<layoutName> with various layout names
- [ ] Verify fuzzy matching works for layout name variations
- [ ] Check toggle_persistence keeps floating keyboard visible when enabled
- [ ] Confirm persistence setting syncs between key action and settings UI
- [ ] Test user feedback (toasts) for both features

🤖 Generated with [Claude Code](https://claude.ai/code)